### PR TITLE
Adding ChainFileListFilter constructors to behave like CompositeFileL…

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/ChainFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/ChainFileListFilter.java
@@ -36,6 +36,19 @@ import org.springframework.util.Assert;
  *
  */
 public class ChainFileListFilter<F> extends CompositeFileListFilter<F> {
+	/**
+	* @inheritDoc
+	*/
+	public ChainFileListFilter() {
+    	super();
+    }
+
+	/**
+	* @inheritDoc
+	*/
+    public ChainFileListFilter(Collection<? extends FileListFilter<F>> fileFilters) {
+        super(fileFilters);
+    }
 
 	@Override
 	public List<F> filterFiles(F[] files) {


### PR DESCRIPTION
…istFilter

Fixing https://github.com/spring-projects/spring-integration/issues/2569
Adding constructors in ChainFileListFilter matching super, so this class behave like CompositeFileListFilter when using XML flow configuration.

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
